### PR TITLE
Fix broken README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A GitHub action for removing emoji from PR content with regex replace.
 
 ## Usage
 
-Create a workflow (eg: `.github/workflows/emoji_strip.yml` see [Creating a Workflow file](https://help.github.com/en/articles/configuring-a-workflow#creating-a-workflow-file))
+Create a workflow (eg: `.github/workflows/emoji_strip.yml` see [Creating a Workflow file](https://docs.github.com/en/actions/use-cases-and-examples/creating-an-example-workflow#creating-an-example-workflow))
 
 ### Example workflow
 This will strip emoji from new PR titles and any text _after_ the Changelog heading only, for any branch, when created or edited.


### PR DESCRIPTION
Was browsing this repo looking at useful ways to create my own github action when I noticed your URL link is broken.

This should be the correct link after comparing the old link using the [wayback machine.](https://web.archive.org/web/20240828082307/https://docs.github.com/en/actions/use-cases-and-examples/creating-an-example-workflow#creating-an-example-workflow) 